### PR TITLE
Implements sequential merging

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,11 @@
+import * as Diff from 'diff';
+
+declare global {
+  namespace Diff {
+    export function applyPatch(
+      source: string,
+      patch: string | Diff.ParsedDiff | [Diff.ParsedDiff],
+      options?: Diff.ApplyPatchOptions,
+    ): string | false;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,12 @@
     "test": "jest --ci --passWithNoTests",
     "test:watch": "jest --watch"
   },
+  "dependencies": {
+    "diff": "5.1.0"
+  },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "4.1.1",
+    "@types/diff": "5.0.3",
     "@types/jest": "29.5.2",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "jest": "29.5.0",
     "prettier": "~2.8.4",
     "prettier-plugin-brace-style": "0.2.1",
+    "prettier-plugin-classnames": "0.1.1",
     "prettier-plugin-tailwindcss": "0.3.0",
     "ts-jest": "29.1.0",
     "typescript": "4.9.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,9 +2,11 @@ lockfileVersion: 5.4
 
 specifiers:
   '@trivago/prettier-plugin-sort-imports': 4.1.1
+  '@types/diff': 5.0.3
   '@types/jest': 29.5.2
   '@typescript-eslint/eslint-plugin': 5.54.0
   '@typescript-eslint/parser': 5.54.0
+  diff: 5.1.0
   eslint: 8.35.0
   eslint-config-airbnb-base: 15.0.0
   eslint-config-airbnb-typescript: 17.0.0
@@ -22,8 +24,12 @@ specifiers:
   vite: 4.3.9
   vite-plugin-dts: 3.0.0-beta.2
 
+dependencies:
+  diff: 5.1.0
+
 devDependencies:
   '@trivago/prettier-plugin-sort-imports': 4.1.1_prettier@2.8.4
+  '@types/diff': 5.0.3
   '@types/jest': 29.5.2
   '@typescript-eslint/eslint-plugin': 5.54.0_6mj2wypvdnknez7kws2nfdgupi
   '@typescript-eslint/parser': 5.54.0_ycpbpc6yetojsgtrx3mwntkhsu
@@ -1118,6 +1124,10 @@ packages:
       '@babel/types': 7.22.4
     dev: true
 
+  /@types/diff/5.0.3:
+    resolution: {integrity: sha512-amrLbRqTU9bXMCc6uX0sWpxsQzRIo9z6MJPkH1pkez/qOxuqSZVuryJAWoBRq94CeG8JxY+VK4Le9HtjQR5T9A==}
+    dev: true
+
   /@types/estree/1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
@@ -1869,6 +1879,11 @@ packages:
     resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
+
+  /diff/5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
+    dev: false
 
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ specifiers:
   jest: 29.5.0
   prettier: ~2.8.4
   prettier-plugin-brace-style: 0.2.1
+  prettier-plugin-classnames: 0.1.1
   prettier-plugin-tailwindcss: 0.3.0
   ts-jest: 29.1.0
   typescript: 4.9.5
@@ -36,6 +37,7 @@ devDependencies:
   jest: 29.5.0
   prettier: 2.8.4
   prettier-plugin-brace-style: 0.2.1_prettier@2.8.4
+  prettier-plugin-classnames: 0.1.1_prettier@2.8.4
   prettier-plugin-tailwindcss: 0.3.0_zmkqdpv3ldc45e6wei6qtrbrca
   ts-jest: 29.1.0_doipufordlnvh5g4adbwayvyvy
   typescript: 4.9.5
@@ -1704,6 +1706,12 @@ packages:
   /cjs-module-lexer/1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
     dev: true
+
+  /classnames/2.3.2:
+    resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /cliui/8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -3815,6 +3823,16 @@ packages:
       prettier: 2.8.4
     optionalDependencies:
       prettier-plugin-merge: 0.1.1_prettier@2.8.4
+    dev: true
+
+  /prettier-plugin-classnames/0.1.1_prettier@2.8.4:
+    resolution: {integrity: sha512-kA1Xp3YQEZJNJwrlu+PlbhNZk2DfzgE6I56C5IANh8eW/+Cmd+2RN2c5Qt1PiMEuw31CyWVTFTnzndFhm6rnmw==}
+    peerDependencies:
+      prettier: ~2.8.4
+    dependencies:
+      prettier: 2.8.4
+    optionalDependencies:
+      classnames: 2.3.2
     dev: true
 
   /prettier-plugin-merge/0.1.1_prettier@2.8.4:

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -1,53 +1,57 @@
 import type { AstPath, ParserOptions, Doc, Printer, Plugin } from 'prettier';
 import { format } from 'prettier';
 
-function printWithMergedPlugin(
-  path: AstPath,
-  options: ParserOptions,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  print: (path: AstPath) => Doc,
-): Doc {
-  const node = path.getValue();
+function createPrinter(): Printer {
+  function main(
+    path: AstPath,
+    options: ParserOptions,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    print: (path: AstPath) => Doc,
+  ): Doc {
+    const node = path.getValue();
 
-  const { originalText } = options;
-  const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
-  const pluginIndex = plugins.findIndex(
-    (plugin) =>
-      Object.values(plugin.parsers ?? {}).every((parser) => parser.astFormat === 'merging-ast') &&
-      Object.entries(plugin.printers ?? {}).every(
-        ([astFormat, printer]) =>
-          astFormat === 'merging-ast' && Object.keys(printer).every((key) => key === 'print'),
-      ),
-  );
-
-  if (pluginIndex === -1) {
-    throw new Error(
-      "The structure of this plugin may have changed. If it's not in development, you may need to report an issue.",
+    const { originalText } = options;
+    const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
+    const pluginIndex = plugins.findIndex(
+      (plugin) =>
+        Object.values(plugin.parsers ?? {}).every((parser) => parser.astFormat === 'merging-ast') &&
+        Object.entries(plugin.printers ?? {}).every(
+          ([astFormat, printer]) =>
+            astFormat === 'merging-ast' && Object.keys(printer).every((key) => key === 'print'),
+        ),
     );
+
+    if (pluginIndex === -1) {
+      throw new Error(
+        "The structure of this plugin may have changed. If it's not in development, you may need to report an issue.",
+      );
+    }
+
+    const sequentiallyFormattedText = plugins.slice(0, pluginIndex).reduce(
+      (previousText, plugin) =>
+        format(previousText, {
+          ...options,
+          plugins: [plugin],
+          rangeEnd: Infinity,
+        }),
+      originalText,
+    );
+
+    if (node?.comments) {
+      node.comments.forEach((comment: any) => {
+        // eslint-disable-next-line no-param-reassign
+        comment.printed = true;
+      });
+    }
+
+    return sequentiallyFormattedText;
   }
 
-  const sequentiallyFormattedText = plugins.slice(0, pluginIndex).reduce(
-    (previousText, plugin) =>
-      format(previousText, {
-        ...options,
-        plugins: [plugin],
-        rangeEnd: Infinity,
-      }),
-    originalText,
-  );
-
-  if (node?.comments) {
-    node.comments.forEach((comment: any) => {
-      // eslint-disable-next-line no-param-reassign
-      comment.printed = true;
-    });
-  }
-
-  return sequentiallyFormattedText;
+  return {
+    print: main,
+  };
 }
 
 export const printers: { [astFormat: string]: Printer } = {
-  'merging-ast': {
-    print: printWithMergedPlugin,
-  },
+  'merging-ast': createPrinter(),
 };

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -1,19 +1,120 @@
+import * as Diff from 'diff';
 import type { AstPath, ParserOptions, Doc, Printer, Plugin } from 'prettier';
 import { format } from 'prettier';
 
-function sequentialFormatting(options: ParserOptions, plugins: Plugin[]): string {
+function sequentialFormattingAndTryMerging(
+  options: ParserOptions,
+  plugins: Plugin[],
+  defaultPlugin: Plugin,
+): string {
+  const parserName = options.parser as string;
   const { originalText } = options;
-  const sequentiallyFormattedText = plugins.reduce(
-    (previousText, plugin) =>
-      format(previousText, {
-        ...options,
-        plugins: [plugin],
-        rangeEnd: Infinity,
-      }),
-    originalText,
-  );
+  const sequentialFormattingOptions = {
+    ...options,
+    rangeEnd: Infinity,
+  };
 
-  return sequentiallyFormattedText;
+  let sequentiallyFormattedText = originalText;
+  let sequentiallyMergedText: string | undefined;
+
+  /**
+   * Changes that may be removed during the sequential formatting process.
+   */
+  const patches: string[] = [];
+
+  plugins.forEach((plugin) => {
+    sequentiallyFormattedText = format(sequentiallyFormattedText, {
+      ...sequentialFormattingOptions,
+      plugins: [plugin],
+    });
+
+    const temporaryFormattedText = format(sequentiallyMergedText ?? originalText, {
+      ...sequentialFormattingOptions,
+      plugins: [plugin],
+    });
+
+    if (sequentiallyMergedText === undefined) {
+      sequentiallyMergedText = temporaryFormattedText;
+      return;
+    }
+
+    const pluginParser = plugin.parsers?.[parserName];
+    const pluginAstFormat = pluginParser?.astFormat;
+    const defaultPluginPrinter =
+      defaultPlugin.printers?.[defaultPlugin.parsers?.[parserName].astFormat ?? ''];
+
+    const temporaryFormattedTextWithoutPrinter =
+      pluginAstFormat && defaultPluginPrinter
+        ? format(temporaryFormattedText, {
+            ...sequentialFormattingOptions,
+            plugins: [
+              {
+                ...plugin,
+                printers: {
+                  ...plugin.printers,
+                  [pluginAstFormat]: defaultPluginPrinter,
+                },
+              },
+            ],
+          })
+        : temporaryFormattedText;
+
+    if (temporaryFormattedTextWithoutPrinter !== temporaryFormattedText) {
+      patches.push(
+        Diff.createPatch(
+          'merging-text',
+          temporaryFormattedTextWithoutPrinter,
+          temporaryFormattedText,
+        ),
+      );
+    }
+
+    if (patches.length === 0) {
+      sequentiallyMergedText = temporaryFormattedText;
+      return;
+    }
+
+    const changes = Diff.diffLines(sequentiallyMergedText, temporaryFormattedText);
+    let fuzzFactorSum = 0;
+
+    changes.forEach((change, index) => {
+      if ('added' in change && 'removed' in change && change.added && !change.removed) {
+        const conjugate = changes[index - 1];
+
+        if (
+          'added' in conjugate &&
+          'removed' in conjugate &&
+          !conjugate.added &&
+          conjugate.removed
+        ) {
+          fuzzFactorSum += Math.max(change.count ?? 0, conjugate.count ?? 0);
+        }
+      }
+    });
+
+    try {
+      let patchedText = temporaryFormattedTextWithoutPrinter;
+
+      patches.forEach((patch) => {
+        const partialPatchedTextOrNot = Diff.applyPatch(patchedText, patch, {
+          fuzzFactor: fuzzFactorSum,
+        });
+
+        if (partialPatchedTextOrNot === false) {
+          throw new Error('Patch failed.');
+        }
+
+        patchedText = partialPatchedTextOrNot;
+      });
+
+      sequentiallyMergedText = patchedText;
+    } catch (_) {
+      // fallback
+      sequentiallyMergedText = sequentiallyFormattedText;
+    }
+  });
+
+  return sequentiallyMergedText ?? sequentiallyFormattedText;
 }
 
 function createPrinter(): Printer {
@@ -23,6 +124,15 @@ function createPrinter(): Printer {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     print: (path: AstPath) => Doc,
   ): Doc {
+    const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
+    const defaultPluginCandidate = plugins.find(
+      (plugin) => typeof options.parser === 'string' && plugin.parsers?.[options.parser],
+    );
+
+    if (!defaultPluginCandidate) {
+      throw new Error('A default plugin with the detected parser does not exist.');
+    }
+
     const node = path.getValue();
 
     if (node?.comments) {
@@ -32,7 +142,6 @@ function createPrinter(): Printer {
       });
     }
 
-    const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
     const pluginIndex = plugins.findIndex(
       (plugin) =>
         Object.values(plugin.parsers ?? {}).every((parser) => parser.astFormat === 'merging-ast') &&
@@ -48,7 +157,11 @@ function createPrinter(): Printer {
       );
     }
 
-    return sequentialFormatting(options, plugins.slice(0, pluginIndex));
+    return sequentialFormattingAndTryMerging(
+      options,
+      plugins.slice(0, pluginIndex),
+      defaultPluginCandidate,
+    );
   }
 
   return {

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -1,6 +1,21 @@
 import type { AstPath, ParserOptions, Doc, Printer, Plugin } from 'prettier';
 import { format } from 'prettier';
 
+function sequentialFormatting(options: ParserOptions, plugins: Plugin[]): string {
+  const { originalText } = options;
+  const sequentiallyFormattedText = plugins.reduce(
+    (previousText, plugin) =>
+      format(previousText, {
+        ...options,
+        plugins: [plugin],
+        rangeEnd: Infinity,
+      }),
+    originalText,
+  );
+
+  return sequentiallyFormattedText;
+}
+
 function createPrinter(): Printer {
   function main(
     path: AstPath,
@@ -33,18 +48,7 @@ function createPrinter(): Printer {
       );
     }
 
-    const { originalText } = options;
-    const sequentiallyFormattedText = plugins.slice(0, pluginIndex).reduce(
-      (previousText, plugin) =>
-        format(previousText, {
-          ...options,
-          plugins: [plugin],
-          rangeEnd: Infinity,
-        }),
-      originalText,
-    );
-
-    return sequentiallyFormattedText;
+    return sequentialFormatting(options, plugins.slice(0, pluginIndex));
   }
 
   return {

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -10,7 +10,13 @@ function createPrinter(): Printer {
   ): Doc {
     const node = path.getValue();
 
-    const { originalText } = options;
+    if (node?.comments) {
+      node.comments.forEach((comment: any) => {
+        // eslint-disable-next-line no-param-reassign
+        comment.printed = true;
+      });
+    }
+
     const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
     const pluginIndex = plugins.findIndex(
       (plugin) =>
@@ -27,6 +33,7 @@ function createPrinter(): Printer {
       );
     }
 
+    const { originalText } = options;
     const sequentiallyFormattedText = plugins.slice(0, pluginIndex).reduce(
       (previousText, plugin) =>
         format(previousText, {
@@ -36,13 +43,6 @@ function createPrinter(): Printer {
         }),
       originalText,
     );
-
-    if (node?.comments) {
-      node.comments.forEach((comment: any) => {
-        // eslint-disable-next-line no-param-reassign
-        comment.printed = true;
-      });
-    }
 
     return sequentiallyFormattedText;
   }

--- a/tests/babel/multiple-plugin.test.ts
+++ b/tests/babel/multiple-plugin.test.ts
@@ -5,6 +5,7 @@ import {
   format,
   sortImportsPlugin,
   braceStylePlugin,
+  classnamesPlugin,
   tailwindcssPlugin,
   baseOptions,
 } from '../settings';
@@ -338,6 +339,220 @@ export default function Counter({ label = "Counter", onChange = undefined })
     options: {
       plugins: [braceStylePlugin, tailwindcssPlugin, mergePlugin],
       ...braceStylePluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #7 (sort-imports -> classnames)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { useState } from "react";
+
+import { CounterContainer } from "@/layouts";
+
+import { CounterButton } from "./parts";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [sortImportsPlugin, classnamesPlugin, mergePlugin],
+      ...sortImportsPluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #8 (classnames -> sort-imports)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { useState } from "react";
+
+import { CounterContainer } from "@/layouts";
+
+import { CounterButton } from "./parts";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [classnamesPlugin, sortImportsPlugin, mergePlugin],
+      ...sortImportsPluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #9 (brace-style -> classnames)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children })
+{
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [braceStylePlugin, classnamesPlugin, mergePlugin],
+      ...braceStylePluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #10 (classnames -> brace-style)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children })
+{
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [classnamesPlugin, braceStylePlugin, mergePlugin],
+      ...braceStylePluginOptions,
+    },
+  },
+  {
+    name: 'two plugins with some overlapping formatting regions #1 (tailwindcss -> classnames)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4
+        dark:border-neutral-500/30 dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [tailwindcssPlugin, classnamesPlugin, mergePlugin],
+    },
+  },
+  {
+    name: 'two plugins with some overlapping formatting regions #2 (classnames -> tailwindcss)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50
+        px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [classnamesPlugin, tailwindcssPlugin, mergePlugin],
     },
   },
 ];

--- a/tests/babel/multiple-plugin.test.ts
+++ b/tests/babel/multiple-plugin.test.ts
@@ -23,7 +23,7 @@ const options = {
 
 const fixtures: Fixture[] = [
   {
-    name: 'plugins that do not implement printers have no order constraints #1 (sort-imports -> tailwindcss)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #1 (sort-imports -> tailwindcss)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -75,7 +75,7 @@ export default function Counter({ label = "Counter", onChange = undefined }) {
     },
   },
   {
-    name: 'plugins that do not implement printers have no order constraints #2 (tailwindcss -> sort-imports)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #2 (tailwindcss -> sort-imports)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -127,7 +127,7 @@ export default function Counter({ label = "Counter", onChange = undefined }) {
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #1 (sort-imports -> brace-style)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #3 (sort-imports -> brace-style)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -182,7 +182,7 @@ export default function Counter({ label = "Counter", onChange = undefined })
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #2 (brace-style -> sort-imports) - `brace-style` is ignored',
+    name: 'two plugins whose formatting regions are disjoint are commutative #4 (brace-style -> sort-imports)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -211,10 +211,12 @@ import { CounterContainer } from "@/layouts";
 
 import { CounterButton } from "./parts";
 
-export default function Counter({ label = "Counter", onChange = undefined }) {
+export default function Counter({ label = "Counter", onChange = undefined })
+{
   const [count, setCount] = useState(0);
 
-  const incrementHandler = () => {
+  const incrementHandler = () =>
+  {
     setCount((prevCount) => prevCount + 1);
     onChange?.(count + 1);
   };
@@ -235,7 +237,7 @@ export default function Counter({ label = "Counter", onChange = undefined }) {
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #3 (tailwindcss -> brace-style)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #5 (tailwindcss -> brace-style)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -287,7 +289,7 @@ export default function Counter({ label = "Counter", onChange = undefined })
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #4 (brace-style -> tailwindcss) - `brace-style` is ignored',
+    name: 'two plugins whose formatting regions are disjoint are commutative #6 (brace-style -> tailwindcss)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -314,10 +316,12 @@ export default function Counter({ label = 'Counter', onChange = undefined }) {
 import { CounterContainer } from "@/layouts";
 import { useState } from "react";
 
-export default function Counter({ label = "Counter", onChange = undefined }) {
+export default function Counter({ label = "Counter", onChange = undefined })
+{
   const [count, setCount] = useState(0);
 
-  const incrementHandler = () => {
+  const incrementHandler = () =>
+  {
     setCount((prevCount) => prevCount + 1);
     onChange?.(count + 1);
   };

--- a/tests/settings.ts
+++ b/tests/settings.ts
@@ -17,6 +17,7 @@ export type Fixture = {
 export { format } from 'prettier';
 export { default as sortImportsPlugin } from '@trivago/prettier-plugin-sort-imports';
 export { default as braceStylePlugin } from 'prettier-plugin-brace-style';
+export { default as classnamesPlugin } from 'prettier-plugin-classnames';
 
 export const tailwindcssPlugin = {
   parsers: tailwindcssParsers,

--- a/tests/typescript/multiple-plugin.test.ts
+++ b/tests/typescript/multiple-plugin.test.ts
@@ -5,6 +5,7 @@ import {
   format,
   sortImportsPlugin,
   braceStylePlugin,
+  classnamesPlugin,
   tailwindcssPlugin,
   baseOptions,
 } from '../settings';
@@ -416,6 +417,220 @@ export default function Counter({
     options: {
       plugins: [braceStylePlugin, tailwindcssPlugin, mergePlugin],
       ...braceStylePluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #7 (sort-imports -> classnames)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { useState } from "react";
+
+import { CounterContainer } from "@/layouts";
+
+import { CounterButton } from "./parts";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [sortImportsPlugin, classnamesPlugin, mergePlugin],
+      ...sortImportsPluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #8 (classnames -> sort-imports)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { useState } from "react";
+
+import { CounterContainer } from "@/layouts";
+
+import { CounterButton } from "./parts";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [classnamesPlugin, sortImportsPlugin, mergePlugin],
+      ...sortImportsPluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #9 (brace-style -> classnames)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children })
+{
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [braceStylePlugin, classnamesPlugin, mergePlugin],
+      ...braceStylePluginOptions,
+    },
+  },
+  {
+    name: 'two plugins whose formatting regions are disjoint are commutative #10 (classnames -> brace-style)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children })
+{
+  return (
+    <div
+      className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
+        dark:border-neutral-500/30 px-4 py-4 rounded-xl"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [classnamesPlugin, braceStylePlugin, mergePlugin],
+      ...braceStylePluginOptions,
+    },
+  },
+  {
+    name: 'two plugins with some overlapping formatting regions #1 (tailwindcss -> classnames)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4
+        dark:border-neutral-500/30 dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [tailwindcssPlugin, classnamesPlugin, mergePlugin],
+    },
+  },
+  {
+    name: 'two plugins with some overlapping formatting regions #2 (classnames -> tailwindcss)',
+    input: `
+import { CounterButton } from './parts';
+import { CounterContainer } from '@/layouts';
+import { useState } from 'react';
+
+export function Callout({ children }) {
+  return (
+    <div className="bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50 dark:border-neutral-500/30 px-4 py-4 rounded-xl">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `import { CounterButton } from "./parts";
+import { CounterContainer } from "@/layouts";
+import { useState } from "react";
+
+export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50
+        px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      plugins: [classnamesPlugin, tailwindcssPlugin, mergePlugin],
     },
   },
 ];

--- a/tests/typescript/multiple-plugin.test.ts
+++ b/tests/typescript/multiple-plugin.test.ts
@@ -23,7 +23,7 @@ const options = {
 
 const fixtures: Fixture[] = [
   {
-    name: 'plugins that do not implement printers have no order constraints #1 (sort-imports -> tailwindcss)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #1 (sort-imports -> tailwindcss)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -88,7 +88,7 @@ export default function Counter({
     },
   },
   {
-    name: 'plugins that do not implement printers have no order constraints #2 (tailwindcss -> sort-imports)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #2 (tailwindcss -> sort-imports)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -153,7 +153,7 @@ export default function Counter({
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #1 (sort-imports -> brace-style)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #3 (sort-imports -> brace-style)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -221,7 +221,7 @@ export default function Counter({
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #2 (brace-style -> sort-imports) - `brace-style` is ignored',
+    name: 'two plugins whose formatting regions are disjoint are commutative #4 (brace-style -> sort-imports)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -263,10 +263,12 @@ type CounterProps = {
 export default function Counter({
   label = "Counter",
   onChange = undefined,
-}: CounterProps) {
+}: CounterProps)
+{
   const [count, setCount] = useState(0);
 
-  const incrementHandler = () => {
+  const incrementHandler = () =>
+  {
     setCount((prevCount) => prevCount + 1);
     onChange?.(count + 1);
   };
@@ -287,7 +289,7 @@ export default function Counter({
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #3 (tailwindcss -> brace-style)',
+    name: 'two plugins whose formatting regions are disjoint are commutative #5 (tailwindcss -> brace-style)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -352,7 +354,7 @@ export default function Counter({
     },
   },
   {
-    name: 'the plugin implementing the printer may be ignored unless placed immediately before this plugin #4 (brace-style -> tailwindcss) - `brace-style` is ignored',
+    name: 'two plugins whose formatting regions are disjoint are commutative #6 (brace-style -> tailwindcss)',
     input: `
 import { CounterButton } from './parts';
 import { CounterContainer } from '@/layouts';
@@ -392,10 +394,12 @@ type CounterProps = {
 export default function Counter({
   label = "Counter",
   onChange = undefined,
-}: CounterProps) {
+}: CounterProps)
+{
   const [count, setCount] = useState(0);
 
-  const incrementHandler = () => {
+  const incrementHandler = () =>
+  {
     setCount((prevCount) => prevCount + 1);
     onChange?.(count + 1);
   };


### PR DESCRIPTION
In the existing sequential formatting method, some formatting (e.g. brace-style) adjusted by the prettier cannot be preserved, so the following constraints existed in the plugin order.

- Only one plugin such as `prettier-plugin-brace-style` can be applied.
- That plugin must come immediately before this plugin.

This PR resolves the above constraints by preserving some formatting that is adjusted by prettier.

---

(이하 구글 번역기에 넣고 돌린 한국어 원문)

기존의 순차 서식 방식에서는 prettier에 의해 조정되는 일부 서식(예: brace-style)을 보존할 수 없어서 플러그인 순서에 다음과 같은 제약조건이 존재했습니다.

- `prettier-plugin-brace-style`같은 플러그인은 최대 한 개만 적용될 수 있다.
- 그 플러그인은 반드시 이 플러그인 직전에 와야 한다.

이 PR은 prettier에 의해 조정되는 일부 서식을 보존하여 위 제약조건을 해소합니다.