### PR TITLE
Partially reworked the plugin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,10 +94,6 @@ importers:
       prettier:
         specifier: 3.0.3
         version: 3.0.3
-    devDependencies:
-      '@types/node':
-        specifier: 20.2.5
-        version: 20.2.5
 
 packages:
 

--- a/src/packages/v2-plugin/parsers.ts
+++ b/src/packages/v2-plugin/parsers.ts
@@ -1,19 +1,96 @@
-import type { Parser } from 'prettier';
+import type { SubstitutePatch } from 'core-parts';
+import { makePatches, applyPatches } from 'core-parts';
+import type { Parser, ParserOptions, Plugin } from 'prettier';
+import { format } from 'prettier';
 import { parsers as babelParsers } from 'prettier/parser-babel';
 import { parsers as htmlParsers } from 'prettier/parser-html';
 import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 
+function sequentialFormattingAndTryMerging(options: ParserOptions, plugins: Plugin[]): string {
+  const { originalText } = options;
+  const sequentialFormattingOptions = {
+    ...options,
+    rangeEnd: Infinity,
+    plugins: [],
+  };
+
+  const firstFormattedText = format(originalText, sequentialFormattingOptions);
+
+  /**
+   * Changes that may be removed during the sequential formatting process.
+   */
+  const patches: SubstitutePatch[] = [];
+
+  const sequentiallyMergedText = plugins.reduce((formattedPrevText, plugin) => {
+    const temporaryFormattedText = format(formattedPrevText, {
+      ...sequentialFormattingOptions,
+      plugins: [plugin],
+    });
+
+    const temporaryFormattedTextWithoutPlugin = format(
+      temporaryFormattedText,
+      sequentialFormattingOptions,
+    );
+
+    patches.push(...makePatches(temporaryFormattedTextWithoutPlugin, temporaryFormattedText));
+
+    if (patches.length === 0) {
+      return temporaryFormattedText;
+    }
+
+    return applyPatches(temporaryFormattedTextWithoutPlugin, patches);
+  }, firstFormattedText);
+
+  return sequentiallyMergedText;
+}
+
+function transformParser(
+  parserName: 'babel' | 'typescript' | 'vue',
+  defaultParser: Parser,
+): Parser {
+  return {
+    ...defaultParser,
+    parse: (text: string, parsers: { [parserName: string]: Parser }, options: ParserOptions) => {
+      const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
+      const pluginIndex = plugins.findIndex(
+        (plugin) =>
+          Object.values(plugin.parsers ?? {}).every(
+            (parser) => parser.astFormat === 'merging-ast',
+          ) &&
+          Object.entries(plugin.printers ?? {}).every(
+            ([astFormat, printer]) =>
+              astFormat === 'merging-ast' && Object.keys(printer).every((key) => key === 'print'),
+          ),
+      );
+
+      if (pluginIndex === -1) {
+        throw new Error(
+          "The structure of this plugin may have changed. If it's not in development, you may need to report an issue.",
+        );
+      }
+
+      const parserImplementedPlugins = plugins
+        .slice(0, pluginIndex)
+        .filter((plugin) => plugin.parsers?.[parserName]);
+      const result = sequentialFormattingAndTryMerging(
+        {
+          ...options,
+          originalText: text,
+        },
+        parserImplementedPlugins,
+      );
+
+      return {
+        type: 'FormattedText',
+        body: result,
+      };
+    },
+    astFormat: 'merging-ast',
+  };
+}
+
 export const parsers: { [parserName: string]: Parser } = {
-  babel: {
-    ...babelParsers.babel,
-    astFormat: 'merging-ast',
-  },
-  typescript: {
-    ...typescriptParsers.typescript,
-    astFormat: 'merging-ast',
-  },
-  vue: {
-    ...htmlParsers.vue,
-    astFormat: 'merging-ast',
-  },
+  babel: transformParser('babel', babelParsers.babel),
+  typescript: transformParser('typescript', typescriptParsers.typescript),
+  vue: transformParser('vue', htmlParsers.vue),
 };

--- a/src/packages/v2-plugin/printers.ts
+++ b/src/packages/v2-plugin/printers.ts
@@ -1,84 +1,20 @@
-import type { SubstitutePatch } from 'core-parts';
-import { makePatches, applyPatches } from 'core-parts';
-import type { AstPath, ParserOptions, Doc, Printer, Plugin } from 'prettier';
-import { format } from 'prettier';
-
-function sequentialFormattingAndTryMerging(options: ParserOptions, plugins: Plugin[]): string {
-  const { originalText } = options;
-  const sequentialFormattingOptions = {
-    ...options,
-    rangeEnd: Infinity,
-    plugins: [],
-  };
-
-  const firstFormattedText = format(originalText, sequentialFormattingOptions);
-
-  /**
-   * Changes that may be removed during the sequential formatting process.
-   */
-  const patches: SubstitutePatch[] = [];
-
-  const sequentiallyMergedText = plugins.reduce((formattedPrevText, plugin) => {
-    const temporaryFormattedText = format(formattedPrevText, {
-      ...sequentialFormattingOptions,
-      plugins: [plugin],
-    });
-
-    const temporaryFormattedTextWithoutPlugin = format(
-      temporaryFormattedText,
-      sequentialFormattingOptions,
-    );
-
-    patches.push(...makePatches(temporaryFormattedTextWithoutPlugin, temporaryFormattedText));
-
-    if (patches.length === 0) {
-      return temporaryFormattedText;
-    }
-
-    return applyPatches(temporaryFormattedTextWithoutPlugin, patches);
-  }, firstFormattedText);
-
-  return sequentiallyMergedText;
-}
+import type { AstPath, ParserOptions, Doc, Printer } from 'prettier';
 
 function createPrinter(): Printer {
   function main(
     path: AstPath,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options: ParserOptions,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     print: (path: AstPath) => Doc,
   ): Doc {
-    const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
-    const parserName = options.parser as string;
     const node = path.getValue();
 
-    if (node?.comments) {
-      node.comments.forEach((comment: any) => {
-        // eslint-disable-next-line no-param-reassign
-        comment.printed = true;
-      });
+    if (node.type === 'FormattedText') {
+      return node.body;
     }
 
-    const pluginIndex = plugins.findIndex(
-      (plugin) =>
-        Object.values(plugin.parsers ?? {}).every((parser) => parser.astFormat === 'merging-ast') &&
-        Object.entries(plugin.printers ?? {}).every(
-          ([astFormat, printer]) =>
-            astFormat === 'merging-ast' && Object.keys(printer).every((key) => key === 'print'),
-        ),
-    );
-
-    if (pluginIndex === -1) {
-      throw new Error(
-        "The structure of this plugin may have changed. If it's not in development, you may need to report an issue.",
-      );
-    }
-
-    const parserImplementedPlugins = plugins
-      .slice(0, pluginIndex)
-      .filter((plugin) => plugin.parsers?.[parserName]);
-
-    return sequentialFormattingAndTryMerging(options, parserImplementedPlugins);
+    throw new Error(`Unknown node type: ${node?.type}`);
   }
 
   return {

--- a/src/packages/v3-plugin/package.json
+++ b/src/packages/v3-plugin/package.json
@@ -7,8 +7,5 @@
   "dependencies": {
     "core-parts": "workspace:*",
     "prettier": "3.0.3"
-  },
-  "devDependencies": {
-    "@types/node": "20.2.5"
   }
 }

--- a/src/packages/v3-plugin/parsers.ts
+++ b/src/packages/v3-plugin/parsers.ts
@@ -1,19 +1,103 @@
-import type { Parser } from 'prettier';
+import type { SubstitutePatch } from 'core-parts';
+import { makePatches, applyPatches } from 'core-parts';
+import type { Parser, ParserOptions, Plugin } from 'prettier';
+import { format } from 'prettier';
 import { parsers as babelParsers } from 'prettier/plugins/babel';
 import { parsers as htmlParsers } from 'prettier/plugins/html';
 import { parsers as typescriptParsers } from 'prettier/plugins/typescript';
 
+async function sequentialFormattingAndTryMerging(
+  options: ParserOptions,
+  plugins: Plugin[],
+): Promise<string> {
+  const { originalText } = options;
+  const sequentialFormattingOptions = {
+    ...options,
+    rangeEnd: Infinity,
+    plugins: [],
+  };
+
+  const firstFormattedTextPromise = format(originalText, sequentialFormattingOptions);
+
+  /**
+   * Changes that may be removed during the sequential formatting process.
+   */
+  const patches: SubstitutePatch[] = [];
+
+  const sequentiallyMergedText = await plugins.reduce<Promise<string>>(
+    async (formattedPrevTextPromise, plugin) => {
+      const formattedPrevText = await formattedPrevTextPromise;
+      const temporaryFormattedText = await format(formattedPrevText, {
+        ...sequentialFormattingOptions,
+        plugins: [plugin],
+      });
+
+      const temporaryFormattedTextWithoutPlugin = await format(
+        temporaryFormattedText,
+        sequentialFormattingOptions,
+      );
+
+      patches.push(...makePatches(temporaryFormattedTextWithoutPlugin, temporaryFormattedText));
+
+      if (patches.length === 0) {
+        return temporaryFormattedText;
+      }
+
+      return applyPatches(temporaryFormattedTextWithoutPlugin, patches);
+    },
+    firstFormattedTextPromise,
+  );
+
+  return sequentiallyMergedText;
+}
+
+function transformParser(
+  parserName: 'babel' | 'typescript' | 'vue',
+  defaultParser: Parser,
+): Parser {
+  return {
+    ...defaultParser,
+    parse: async (text: string, options: ParserOptions) => {
+      const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
+      const pluginIndex = plugins.findIndex(
+        (plugin) =>
+          Object.values(plugin.parsers ?? {}).every(
+            (parser) => parser.astFormat === 'merging-ast',
+          ) &&
+          Object.entries(plugin.printers ?? {}).every(
+            ([astFormat, printer]) =>
+              astFormat === 'merging-ast' && Object.keys(printer).every((key) => key === 'print'),
+          ),
+      );
+
+      if (pluginIndex === -1) {
+        throw new Error(
+          "The structure of this plugin may have changed. If it's not in development, you may need to report an issue.",
+        );
+      }
+
+      const parserImplementedPlugins = plugins
+        .slice(0, pluginIndex)
+        .filter((plugin) => plugin.parsers?.[parserName]);
+      const result = await sequentialFormattingAndTryMerging(
+        {
+          ...options,
+          originalText: text,
+        },
+        parserImplementedPlugins,
+      );
+
+      return {
+        type: 'FormattedText',
+        body: result,
+      };
+    },
+    astFormat: 'merging-ast',
+  };
+}
+
 export const parsers: { [parserName: string]: Parser } = {
-  babel: {
-    ...babelParsers.babel,
-    astFormat: 'merging-ast',
-  },
-  typescript: {
-    ...typescriptParsers.typescript,
-    astFormat: 'merging-ast',
-  },
-  vue: {
-    ...htmlParsers.vue,
-    astFormat: 'merging-ast',
-  },
+  babel: transformParser('babel', babelParsers.babel),
+  typescript: transformParser('typescript', typescriptParsers.typescript),
+  vue: transformParser('vue', htmlParsers.vue),
 };

--- a/src/packages/v3-plugin/printers.ts
+++ b/src/packages/v3-plugin/printers.ts
@@ -1,158 +1,20 @@
-import type { SubstitutePatch } from 'core-parts';
-import { makePatches, applyPatches } from 'core-parts';
-import type { AstPath, ParserOptions, Doc, Printer, Plugin, Options } from 'prettier';
-import { format, resolveConfig, getFileInfo } from 'prettier';
-import {
-  isMainThread,
-  parentPort,
-  receiveMessageOnPort,
-  MessageChannel,
-  Worker,
-} from 'worker_threads';
-
-function sequentialFormattingAndTryMerging(options: ParserOptions, plugins: Plugin[]): string {
-  const { originalText, filepath } = options;
-  // @ts-ignore
-  const configBasedPluginNames = plugins.map((plugin) => plugin.name).filter(Boolean);
-
-  const signal = new Int32Array(new SharedArrayBuffer(4));
-  const { port1: mainPort, port2: workerPort } = new MessageChannel();
-
-  const worker = new Worker(__filename);
-  worker.unref();
-
-  worker.postMessage(
-    { signal, port: workerPort, payload: { originalText, filepath, configBasedPluginNames } },
-    [workerPort],
-  );
-  Atomics.wait(signal, 0, 0, 3000);
-
-  const response = receiveMessageOnPort(mainPort);
-
-  if (response === undefined) {
-    throw new Error('No response from worker.');
-  }
-  if (response.message.error) {
-    throw new Error(response.message.error);
-  }
-
-  return response.message.result;
-}
-
-if (!isMainThread && parentPort) {
-  parentPort.addListener('message', async ({ signal, port, payload }) => {
-    const response: { result?: string; error?: unknown } = {};
-    const { originalText, filepath, configBasedPluginNames } = payload;
-
-    const resolvedConfig = await resolveConfig(filepath);
-    const sequentialFormattingOptions: Options = {
-      ...Object.fromEntries(
-        Object.entries(resolvedConfig ?? {}).filter(([key]) => key !== 'plugins'),
-      ),
-      rangeEnd: Infinity,
-      plugins: [],
-    };
-    const pluginNames = ((resolvedConfig?.plugins ?? []) as string[]).filter((pluginName) =>
-      configBasedPluginNames.includes(pluginName),
-    );
-
-    const fileInfo = await getFileInfo(filepath);
-    const parserName = fileInfo.inferredParser;
-
-    if (parserName) {
-      sequentialFormattingOptions.parser = parserName;
-    }
-
-    try {
-      const firstFormattedText = await format(originalText, sequentialFormattingOptions);
-
-      /**
-       * Changes that may be removed during the sequential formatting process.
-       */
-      const patches: SubstitutePatch[] = [];
-
-      const sequentiallyMergedText = await pluginNames.reduce<Promise<string>>(
-        async (promise, pluginName) => {
-          const formattedPrevText = await promise;
-          const temporaryFormattedText = await format(formattedPrevText, {
-            ...sequentialFormattingOptions,
-            plugins: [pluginName],
-          });
-
-          const temporaryFormattedTextWithoutPlugin = await format(
-            temporaryFormattedText,
-            sequentialFormattingOptions,
-          );
-
-          patches.push(...makePatches(temporaryFormattedTextWithoutPlugin, temporaryFormattedText));
-
-          if (patches.length === 0) {
-            return temporaryFormattedText;
-          }
-
-          return applyPatches(temporaryFormattedTextWithoutPlugin, patches);
-        },
-        Promise.resolve(firstFormattedText),
-      );
-
-      response.result = sequentiallyMergedText;
-    } catch (error) {
-      response.error = error;
-    }
-
-    try {
-      port.postMessage(response);
-    } catch (error) {
-      port.postMessage({
-        error: new Error("The worker's response could not be serialized."),
-      });
-    } finally {
-      port.close();
-      Atomics.store(signal, 0, 1);
-      Atomics.notify(signal, 0);
-    }
-  });
-}
+import type { AstPath, ParserOptions, Doc, Printer } from 'prettier';
 
 function createPrinter(): Printer {
   function main(
     path: AstPath,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options: ParserOptions,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     print: (path: AstPath) => Doc,
   ): Doc {
-    const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
-    const parserName = options.parser as string;
-    // @ts-ignore
-    const comments = options[Symbol.for('comments')];
+    const { node } = path;
 
-    if (comments) {
-      comments.forEach((comment: any) => {
-        // eslint-disable-next-line no-param-reassign
-        comment.printed = true;
-      });
+    if (node.type === 'FormattedText') {
+      return node.body;
     }
 
-    const pluginIndex = plugins.findIndex(
-      (plugin) =>
-        Object.values(plugin.parsers ?? {}).every((parser) => parser.astFormat === 'merging-ast') &&
-        Object.entries(plugin.printers ?? {}).every(
-          ([astFormat, printer]) =>
-            astFormat === 'merging-ast' && Object.keys(printer).every((key) => key === 'print'),
-        ),
-    );
-
-    if (pluginIndex === -1) {
-      throw new Error(
-        "The structure of this plugin may have changed. If it's not in development, you may need to report an issue.",
-      );
-    }
-
-    const parserImplementedPlugins = plugins
-      .slice(0, pluginIndex)
-      .filter((plugin) => plugin.parsers?.[parserName]);
-
-    return sequentialFormattingAndTryMerging(options, parserImplementedPlugins);
+    throw new Error(`Unknown node type: ${node?.type}`);
   }
 
   return {


### PR DESCRIPTION
This PR closes #15, closes #16, and closes #17.

This plugin and my other prettier plugins ([prettier-plugin-brace-style](https://github.com/ony3000/prettier-plugin-brace-style), [prettier-plugin-classnames](https://github.com/ony3000/prettier-plugin-classnames)) mainly implement the printer among the plugin parts, and the implementation includes code that calls prettier's `format` function.

The `format` function in prettier v2 was executed synchronously, but starting from v3, it is executed asynchronously. However, the plugin's printer still needed to return synchronous results, so I took the implementation idea from [@prettier/sync](https://github.com/prettier/prettier-synchronized).

However, the implementation method using worker threads has the limitation ([The structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)) of not being able to pass functions or objects containing functions (prettier plugins are also included in this category), and is inferior in performance compared to the prettier v2-only plugin implemented without worker threads.

Then recently, while investigating [prettier-plugin-classnames#19](https://github.com/ony3000/prettier-plugin-classnames/issues/19), it occurred to me that the parser in the prettier v3-only plugin can return asynchronous results, so I moved most of the code I had written on the printer side to the parser.