### PR TITLE
Leaves output of each plugin as is for code blocks embedded in markdown and mdx

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(prettier-plugin-astro@0.10.0)(prettier-plugin-svelte@2.10.1)(prettier@2.8.4)
       prettier-plugin-classnames:
-        specifier: 0.7.0
-        version: 0.7.0(prettier-plugin-astro@0.10.0)(prettier-plugin-svelte@2.10.1)(prettier@2.8.4)
+        specifier: 0.7.5
+        version: 0.7.5(prettier-plugin-astro@0.10.0)(prettier-plugin-svelte@2.10.1)(prettier@2.8.4)
       prettier-plugin-svelte:
         specifier: 2.10.1
         version: 2.10.1(prettier@2.8.4)(svelte@4.2.17)
@@ -148,8 +148,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(prettier-plugin-astro@0.11.0)(prettier-plugin-svelte@3.0.0)(prettier@3.0.3)
       prettier-plugin-classnames:
-        specifier: 0.7.0
-        version: 0.7.0(prettier-plugin-astro@0.11.0)(prettier-plugin-svelte@3.0.0)(prettier@3.0.3)
+        specifier: 0.7.5
+        version: 0.7.5(prettier-plugin-astro@0.11.0)(prettier-plugin-svelte@3.0.0)(prettier@3.0.3)
       prettier-plugin-svelte:
         specifier: 3.0.0
         version: 3.0.0(prettier@3.0.3)(svelte@4.2.17)
@@ -2988,8 +2988,8 @@ packages:
       prettier-plugin-svelte: 3.0.0(prettier@3.0.3)(svelte@4.2.17)
     dev: true
 
-  /prettier-plugin-classnames@0.7.0(prettier-plugin-astro@0.10.0)(prettier-plugin-svelte@2.10.1)(prettier@2.8.4):
-    resolution: {integrity: sha512-gxnMyTUPs5rPY/JzjLBsiBFA0Dj9/oukk02fGofAQ+FFzGYNZEHWL8Q9TWXmglgJgBzy2Cx0Az9n+Uk4DtianA==}
+  /prettier-plugin-classnames@0.7.5(prettier-plugin-astro@0.10.0)(prettier-plugin-svelte@2.10.1)(prettier@2.8.4):
+    resolution: {integrity: sha512-HQ2631Tbey4aK4CX8oUnDKj5mlWy20TfWa3CrPOf/IqLyOmIrDeV7aeDjOSwVgsNbfsqO8zxPwiu/PRKihiv0A==}
     engines: {node: '>=14'}
     peerDependencies:
       prettier: ^2 || ^3
@@ -3006,8 +3006,8 @@ packages:
       prettier-plugin-svelte: 2.10.1(prettier@2.8.4)(svelte@4.2.17)
     dev: true
 
-  /prettier-plugin-classnames@0.7.0(prettier-plugin-astro@0.11.0)(prettier-plugin-svelte@3.0.0)(prettier@3.0.3):
-    resolution: {integrity: sha512-gxnMyTUPs5rPY/JzjLBsiBFA0Dj9/oukk02fGofAQ+FFzGYNZEHWL8Q9TWXmglgJgBzy2Cx0Az9n+Uk4DtianA==}
+  /prettier-plugin-classnames@0.7.5(prettier-plugin-astro@0.11.0)(prettier-plugin-svelte@3.0.0)(prettier@3.0.3):
+    resolution: {integrity: sha512-HQ2631Tbey4aK4CX8oUnDKj5mlWy20TfWa3CrPOf/IqLyOmIrDeV7aeDjOSwVgsNbfsqO8zxPwiu/PRKihiv0A==}
     engines: {node: '>=14'}
     peerDependencies:
       prettier: ^2 || ^3

--- a/src/packages/v2-plugin/parsers.ts
+++ b/src/packages/v2-plugin/parsers.ts
@@ -6,6 +6,33 @@ import { parsers as babelParsers } from 'prettier/parser-babel';
 import { parsers as htmlParsers } from 'prettier/parser-html';
 import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 
+const EOL = '\n';
+
+function formatAsCodeblock(text: string, options: ParserOptions, plugins?: Plugin[]) {
+  let codeblockStart = '```';
+  const codeblockEnd = '```';
+
+  if (options.parser === 'babel') {
+    codeblockStart = '```jsx';
+  } else if (options.parser === 'typescript') {
+    codeblockStart = '```tsx';
+  }
+
+  const formattedCodeblock = format(`${codeblockStart}${EOL}${text}${EOL}${codeblockEnd}`, {
+    ...options,
+    plugins: plugins ?? [],
+    rangeEnd: Infinity,
+    endOfLine: 'lf',
+    parser: options.parentParser,
+    parentParser: undefined,
+  });
+  const formattedText = formattedCodeblock
+    .trim()
+    .slice(`${codeblockStart}${EOL}`.length, -`${EOL}${codeblockEnd}`.length);
+
+  return formattedText;
+}
+
 function sequentialFormattingAndTryMerging(
   options: ParserOptions,
   plugins: Plugin[],
@@ -23,7 +50,10 @@ function sequentialFormattingAndTryMerging(
     plugins: customLanguageSupportedPlugins,
   };
 
-  const firstFormattedText = format(originalText, sequentialFormattingOptions);
+  const firstFormattedText =
+    options.parentParser === 'markdown' || options.parentParser === 'mdx'
+      ? formatAsCodeblock(originalText, options)
+      : format(originalText, sequentialFormattingOptions);
 
   /**
    * Changes that may be removed during the sequential formatting process.
@@ -31,15 +61,21 @@ function sequentialFormattingAndTryMerging(
   const patches: SubstitutePatch[] = [];
 
   const sequentiallyMergedText = plugins.reduce((formattedPrevText, plugin) => {
-    const temporaryFormattedText = format(formattedPrevText, {
-      ...sequentialFormattingOptions,
-      plugins: [...customLanguageSupportedPlugins, plugin],
-    });
+    const temporaryFormattedText =
+      options.parentParser === 'markdown' || options.parentParser === 'mdx'
+        ? formatAsCodeblock(formattedPrevText, sequentialFormattingOptions, [
+            ...customLanguageSupportedPlugins,
+            plugin,
+          ])
+        : format(formattedPrevText, {
+            ...sequentialFormattingOptions,
+            plugins: [...customLanguageSupportedPlugins, plugin],
+          });
 
-    const temporaryFormattedTextWithoutPlugin = format(
-      temporaryFormattedText,
-      sequentialFormattingOptions,
-    );
+    const temporaryFormattedTextWithoutPlugin =
+      options.parentParser === 'markdown' || options.parentParser === 'mdx'
+        ? formatAsCodeblock(temporaryFormattedText, sequentialFormattingOptions)
+        : format(temporaryFormattedText, sequentialFormattingOptions);
 
     patches.push(...makePatches(temporaryFormattedTextWithoutPlugin, temporaryFormattedText));
 

--- a/tests/v2-test/adaptor.ts
+++ b/tests/v2-test/adaptor.ts
@@ -66,16 +66,18 @@ export function testSnapshotEach(
       expect(formattedText).toMatchSnapshot();
     });
 
-    test('consistency; when you have less than one plugin, adding a merge plugin should have the same result', ({
+    test('consistency; if there are no plugins or only one, adding a merge plugin should have the same result', ({
       skip,
     }) => {
-      if (skipSecondTest || (fixedOptions.plugins ?? []).length > 1) {
+      const fixedPlugins = fixedOptions.plugins ?? [];
+
+      if (skipSecondTest || fixedPlugins.length > 1) {
         skip();
       }
 
       const formattedTextWithThisPlugin = format(formattedText, {
         ...fixedOptions,
-        plugins: [...(fixedOptions.plugins ?? []), thisPlugin],
+        plugins: [...fixedPlugins, thisPlugin],
       });
 
       expect(formattedTextWithThisPlugin).toBe(formattedText);

--- a/tests/v2-test/adaptor.ts
+++ b/tests/v2-test/adaptor.ts
@@ -4,7 +4,7 @@ import { parsers as babelParsers } from 'prettier/parser-babel';
 import { parsers as htmlParsers } from 'prettier/parser-html';
 import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 import type { Fixture } from 'test-settings';
-import { expect, test } from 'vitest';
+import { describe, expect, onTestFailed, test } from 'vitest';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as thisPlugin from '@/packages/v2-plugin';
@@ -43,6 +43,43 @@ export function testEach(fixtures: Fixture[], options: PrettierBaseOptions & { p
     const formattedText = format(input, fixedOptions);
 
     expect(formattedText).toBe(output);
+  });
+}
+
+export function testSnapshotEach(
+  fixtures: Omit<Fixture, 'output'>[],
+  options: PrettierBaseOptions & { parser: string },
+) {
+  describe.each(fixtures)('$name', ({ input, options: fixtureOptions }) => {
+    const fixedOptions = {
+      ...options,
+      ...(fixtureOptions ?? {}),
+    };
+    const formattedText = format(input, fixedOptions);
+    let skipSecondTest = false;
+
+    test('expectation', () => {
+      onTestFailed(() => {
+        skipSecondTest = true;
+      });
+
+      expect(formattedText).toMatchSnapshot();
+    });
+
+    test('consistency; when you have less than one plugin, adding a merge plugin should have the same result', ({
+      skip,
+    }) => {
+      if (skipSecondTest || (fixedOptions.plugins ?? []).length > 1) {
+        skip();
+      }
+
+      const formattedTextWithThisPlugin = format(formattedText, {
+        ...fixedOptions,
+        plugins: [...(fixedOptions.plugins ?? []), thisPlugin],
+      });
+
+      expect(formattedTextWithThisPlugin).toBe(formattedText);
+    });
   });
 }
 

--- a/tests/v2-test/markdown/__snapshots__/single-plugin.test.ts.snap
+++ b/tests/v2-test/markdown/__snapshots__/single-plugin.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) This plugin doesn\\'t support markdown parser, so it leaves the output of each plugin as is.' > expectation 1`] = `
+"\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/markdown/single-plugin.test.ts
+++ b/tests/v2-test/markdown/single-plugin.test.ts
@@ -1,0 +1,31 @@
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+
+import { testSnapshotEach } from '../adaptor';
+
+const options = {
+  ...baseOptions,
+  parser: 'markdown',
+};
+
+const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support markdown parser, so it leaves the output of each plugin as is.",
+    input: `
+\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+`,
+    options: {
+      plugins: ['prettier-plugin-classnames'],
+    },
+  },
+];
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/mdx/__snapshots__/single-plugin.test.ts.snap
+++ b/tests/v2-test/mdx/__snapshots__/single-plugin.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) This plugin doesn\\'t support mdx parser, so it leaves the output of each plugin as is.' > expectation 1`] = `
+"\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/mdx/single-plugin.test.ts
+++ b/tests/v2-test/mdx/single-plugin.test.ts
@@ -1,0 +1,31 @@
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+
+import { testSnapshotEach } from '../adaptor';
+
+const options = {
+  ...baseOptions,
+  parser: 'mdx',
+};
+
+const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support mdx parser, so it leaves the output of each plugin as is.",
+    input: `
+\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+`,
+    options: {
+      plugins: ['prettier-plugin-classnames'],
+    },
+  },
+];
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/package.json
+++ b/tests/v2-test/package.json
@@ -12,7 +12,7 @@
     "prettier": "2.8.4",
     "prettier-plugin-astro": "0.10.0",
     "prettier-plugin-brace-style": "0.7.0",
-    "prettier-plugin-classnames": "0.7.0",
+    "prettier-plugin-classnames": "0.7.5",
     "prettier-plugin-svelte": "2.10.1",
     "prettier-plugin-tailwindcss": "0.4.1",
     "test-settings": "workspace:*",

--- a/tests/v3-test/adaptor.ts
+++ b/tests/v3-test/adaptor.ts
@@ -66,16 +66,18 @@ export function testSnapshotEach(
       expect(formattedText).toMatchSnapshot();
     });
 
-    test('consistency; when you have less than one plugin, adding a merge plugin should have the same result', async ({
+    test('consistency; if there are no plugins or only one, adding a merge plugin should have the same result', async ({
       skip,
     }) => {
-      if (skipSecondTest || (fixedOptions.plugins ?? []).length > 1) {
+      const fixedPlugins = fixedOptions.plugins ?? [];
+
+      if (skipSecondTest || fixedPlugins.length > 1) {
         skip();
       }
 
       const formattedTextWithThisPlugin = await format(formattedText, {
         ...fixedOptions,
-        plugins: [...(fixedOptions.plugins ?? []), thisPlugin],
+        plugins: [...fixedPlugins, thisPlugin],
       });
 
       expect(formattedTextWithThisPlugin).toBe(formattedText);

--- a/tests/v3-test/adaptor.ts
+++ b/tests/v3-test/adaptor.ts
@@ -4,7 +4,7 @@ import { parsers as babelParsers } from 'prettier/plugins/babel';
 import { parsers as htmlParsers } from 'prettier/plugins/html';
 import { parsers as typescriptParsers } from 'prettier/plugins/typescript';
 import type { Fixture } from 'test-settings';
-import { expect, test } from 'vitest';
+import { describe, expect, onTestFailed, test } from 'vitest';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as thisPlugin from '@/packages/v3-plugin';
@@ -43,6 +43,43 @@ export function testEach(fixtures: Fixture[], options: PrettierBaseOptions & { p
     const formattedText = await format(input, fixedOptions);
 
     expect(formattedText).toBe(output);
+  });
+}
+
+export function testSnapshotEach(
+  fixtures: Omit<Fixture, 'output'>[],
+  options: PrettierBaseOptions & { parser: string },
+) {
+  describe.each(fixtures)('$name', async ({ input, options: fixtureOptions }) => {
+    const fixedOptions = {
+      ...options,
+      ...(fixtureOptions ?? {}),
+    };
+    const formattedText = await format(input, fixedOptions);
+    let skipSecondTest = false;
+
+    test('expectation', () => {
+      onTestFailed(() => {
+        skipSecondTest = true;
+      });
+
+      expect(formattedText).toMatchSnapshot();
+    });
+
+    test('consistency; when you have less than one plugin, adding a merge plugin should have the same result', async ({
+      skip,
+    }) => {
+      if (skipSecondTest || (fixedOptions.plugins ?? []).length > 1) {
+        skip();
+      }
+
+      const formattedTextWithThisPlugin = await format(formattedText, {
+        ...fixedOptions,
+        plugins: [...(fixedOptions.plugins ?? []), thisPlugin],
+      });
+
+      expect(formattedTextWithThisPlugin).toBe(formattedText);
+    });
   });
 }
 

--- a/tests/v3-test/markdown/__snapshots__/single-plugin.test.ts.snap
+++ b/tests/v3-test/markdown/__snapshots__/single-plugin.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) This plugin doesn\\'t support markdown parser, so it leaves the output of each plugin as is.' > expectation 1`] = `
+"\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/markdown/single-plugin.test.ts
+++ b/tests/v3-test/markdown/single-plugin.test.ts
@@ -1,0 +1,31 @@
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+
+import { testSnapshotEach } from '../adaptor';
+
+const options = {
+  ...baseOptions,
+  parser: 'markdown',
+};
+
+const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support markdown parser, so it leaves the output of each plugin as is.",
+    input: `
+\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+`,
+    options: {
+      plugins: ['prettier-plugin-classnames'],
+    },
+  },
+];
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/mdx/__snapshots__/single-plugin.test.ts.snap
+++ b/tests/v3-test/mdx/__snapshots__/single-plugin.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) This plugin doesn\\'t support mdx parser, so it leaves the output of each plugin as is.' > expectation 1`] = `
+"\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/mdx/single-plugin.test.ts
+++ b/tests/v3-test/mdx/single-plugin.test.ts
@@ -1,0 +1,31 @@
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+
+import { testSnapshotEach } from '../adaptor';
+
+const options = {
+  ...baseOptions,
+  parser: 'mdx',
+};
+
+const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support mdx parser, so it leaves the output of each plugin as is.",
+    input: `
+\`\`\`jsx
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+\`\`\`
+`,
+    options: {
+      plugins: ['prettier-plugin-classnames'],
+    },
+  },
+];
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/package.json
+++ b/tests/v3-test/package.json
@@ -12,7 +12,7 @@
     "prettier": "3.0.3",
     "prettier-plugin-astro": "0.11.0",
     "prettier-plugin-brace-style": "0.7.0",
-    "prettier-plugin-classnames": "0.7.0",
+    "prettier-plugin-classnames": "0.7.5",
     "prettier-plugin-svelte": "3.0.0",
     "prettier-plugin-tailwindcss": "0.5.2",
     "test-settings": "workspace:*",


### PR DESCRIPTION
Refs: [prettier-plugin-classnames#80](https://github.com/ony3000/prettier-plugin-classnames/issues/80)