### PR TITLE
Increase the minimum required Node.js version to 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "packageManager": "pnpm@10.10.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=17"
   }
 }


### PR DESCRIPTION
This PR aligns with the spec for `prettier-plugin-classnames`.