### PR TITLE
Find the correct parser by searching within the plugin.name property

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -138,7 +138,7 @@ function transformParser(
           .filter(
             (plugin) =>
               // @ts-expect-error: `name` is presumed to be injected internally by Prettier.
-              plugin.name === externalPluginName,
+              plugin.name?.includes(externalPluginName),
           )
           .at(0);
 


### PR DESCRIPTION
This fixes #48 for me.

The underlying cause was that `plugin.name` was the path to the actual plugin JS file.

This fix should not break anything because it simply widens the matching criteria for finding a plugin. (The previous `===` is still being matched)